### PR TITLE
fix(echo): avoid duplicated body response

### DIFF
--- a/echo/echo.go
+++ b/echo/echo.go
@@ -11,6 +11,9 @@ func New(doc redoc.Redoc) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {
 			handle(ctx.Response(), ctx.Request())
+			if ctx.Response().Committed {
+				return nil
+			}
 			return next(ctx)
 		}
 	}


### PR DESCRIPTION
current echo impl :

```go
func New(doc redoc.Redoc) echo.MiddlewareFunc {
	handle := doc.Handler()

	return func(next echo.HandlerFunc) echo.HandlerFunc {
		return func(ctx echo.Context) error {
			handle(ctx.Response(), ctx.Request())
			return next(ctx)
		}
	}
}
```

the bug is, when `handle(ctx.Response(), ctx.Request())` write body to client, it not return.

so `next(ctx)` contineu to write body to client. which cause problem.
