### PR TITLE
Features: allow use $ref import sub spec files 

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -5,6 +5,8 @@
   <title>{{ .title }}</title>
   <meta name="description" content="{{ .description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
   <style>
   body {
 	margin: 0;
@@ -13,8 +15,7 @@
   </style>
 </head>
 <body>
-  <div id="main"></div>
-  <script>{{ .body }}</script>
-  <script>Redoc.init("{{ .url }}", {}, document.getElementById("main"))</script>
+  <redoc spec-url="{{ .url }}"></redoc>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/redoc.go
+++ b/redoc.go
@@ -107,18 +107,29 @@ func (r Redoc) Handler() http.HandlerFunc {
 			header.Set("Content-Type", "text/html")
 			_, _ = w.Write(data)
 			w.WriteHeader(200)
+
+			return
 		}
 
-		// load sub spec
-		p := filepath.Join(r.SpecDir, filepath.FromSlash(req.URL.Path))
-		subSpec, err := ioutil.ReadFile(p)
-		header.Set("Content-Type", "application/json")
+		// load spec files
+		ext := filepath.Ext(req.URL.Path)
+		if ext == ".yaml" || ext == ".json" {
+			header.Set("Content-Type", "application/json")
+			p := filepath.Join(r.SpecDir, filepath.FromSlash(req.URL.Path))
+			subSpec, err := ioutil.ReadFile(p)
 
-		if err != nil {
-			w.WriteHeader(404)
-		} else {
+			if err != nil {
+				_, _ = w.Write([]byte("file not found."))
+				w.WriteHeader(404)
+
+				return
+			}
+
 			_, _ = w.Write(subSpec)
 			w.WriteHeader(200)
+
+			return
 		}
+
 	}
 }

--- a/redoc.go
+++ b/redoc.go
@@ -33,7 +33,7 @@ var HTML string
 // JavaScript represents the redoc standalone javascript
 //
 //go:embed assets/redoc.standalone.js
-// var JavaScript string
+var JavaScript string
 
 // Body returns the final html with the js in the body
 func (r Redoc) Body() ([]byte, error) {
@@ -44,7 +44,7 @@ func (r Redoc) Body() ([]byte, error) {
 	}
 
 	if err = tpl.Execute(buf, map[string]string{
-		// "body":        JavaScript,
+		"body":        JavaScript,
 		"title":       r.Title,
 		"url":         r.SpecPath,
 		"description": r.Description,

--- a/redoc.go
+++ b/redoc.go
@@ -33,7 +33,7 @@ var HTML string
 // JavaScript represents the redoc standalone javascript
 //
 //go:embed assets/redoc.standalone.js
-var JavaScript string
+// var JavaScript string
 
 // Body returns the final html with the js in the body
 func (r Redoc) Body() ([]byte, error) {
@@ -44,7 +44,7 @@ func (r Redoc) Body() ([]byte, error) {
 	}
 
 	if err = tpl.Execute(buf, map[string]string{
-		"body":        JavaScript,
+		// "body":        JavaScript,
 		"title":       r.Title,
 		"url":         r.SpecPath,
 		"description": r.Description,


### PR DESCRIPTION
Hi @mvrilo  , I really like this repo, it helps me a lot.

I was in trouble on using $ref to import outside spec. And I figure out those yaml files haven't been loaded on browser side.
So I edited this change allows browser to access extended spec files.
And also add new setting `SpecDir` for specifying accessible directory.

<img width="439" alt="Screenshot 2023-08-23 at 2 18 31 PM" src="https://github.com/mvrilo/go-redoc/assets/12434914/50def9f5-3683-4aee-a965-dca501c4d5b3">

<img width="460" alt="Screenshot 2023-08-23 at 2 17 30 PM" src="https://github.com/mvrilo/go-redoc/assets/12434914/0e0c5383-a17c-4191-865b-ba04827511e6">