### PR TITLE
Don't trigger superfluous logs

### DIFF
--- a/redoc.go
+++ b/redoc.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"embed"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -93,21 +92,15 @@ func (r Redoc) Handler() http.HandlerFunc {
 		header := w.Header()
 		if strings.HasSuffix(req.URL.Path, r.SpecPath) {
 			header.Set("Content-Type", "application/json")
-			_, err = w.Write(spec)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(fmt.Sprintf("error writing openapi spec: %s", err)))
-			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(spec)
 			return
 		}
 
 		if docsPath == "" || docsPath == req.URL.Path {
 			header.Set("Content-Type", "text/html")
-			_, err = w.Write(data)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(fmt.Sprintf("error writing redoc: %s", err)))
-			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(data)
 		}
 	}
 }

--- a/redoc.go
+++ b/redoc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -92,15 +93,21 @@ func (r Redoc) Handler() http.HandlerFunc {
 		header := w.Header()
 		if strings.HasSuffix(req.URL.Path, r.SpecPath) {
 			header.Set("Content-Type", "application/json")
-			_, _ = w.Write(spec)
-			w.WriteHeader(200)
+			_, err = w.Write(spec)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(fmt.Sprintf("error writing openapi spec: %s", err)))
+			}
 			return
 		}
 
 		if docsPath == "" || docsPath == req.URL.Path {
 			header.Set("Content-Type", "text/html")
-			_, _ = w.Write(data)
-			w.WriteHeader(200)
+			_, err = w.Write(data)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(fmt.Sprintf("error writing redoc: %s", err)))
+			}
 		}
 	}
 }


### PR DESCRIPTION
When an http.ResponseWriter calls `WriteHeader` after calling `Write` it will log a statement to stderr: `2023/12/29 22:54:08 http: superfluous response.WriteHeader call from github.com/mvrilo/go-redoc.Redoc.Handler.func1 (redoc.go:96)`.

This is happening because the [stdlib http code](https://github.com/golang/go/blob/master/src/net/http/server.go#L1157C28-L1157C28) doesn't want the caller to set the response header after calling Write. This PR moves the call to WriteHeader above the Write call to prevent this log from being generated.